### PR TITLE
nil pointer dereference crashed the server

### DIFF
--- a/server/src/server/server.go
+++ b/server/src/server/server.go
@@ -202,7 +202,13 @@ func advance(tokens []*set.Token) {
 
 func interrogate(tokens []*set.Token) bool {
     for i := range tokens {
-        if *tokens[i] != *TOKENS[LOOKUP[tokens[i].Id]] {
+        if (tokens[i] == nil) && (TOKENS[LOOKUP[tokens[i].Id]] == nil) {
+            return true
+        } else if tokens[i] == nil {
+            return false
+        } else if TOKENS[LOOKUP[tokens[i].Id]] == nil {
+            return false
+        } else if *tokens[i] != *TOKENS[LOOKUP[tokens[i].Id]] {
             return false
         }
     }

--- a/server/src/server/server.go
+++ b/server/src/server/server.go
@@ -202,13 +202,8 @@ func advance(tokens []*set.Token) {
 
 func interrogate(tokens []*set.Token) bool {
     for i := range tokens {
-        if (tokens[i] == nil) && (TOKENS[LOOKUP[tokens[i].Id]] == nil) {
-            return true
-        } else if tokens[i] == nil {
-            return false
-        } else if TOKENS[LOOKUP[tokens[i].Id]] == nil {
-            return false
-        } else if *tokens[i] != *TOKENS[LOOKUP[tokens[i].Id]] {
+        if (tokens[i] == nil) || (TOKENS[LOOKUP[tokens[i].Id]] == nil) ||
+            (*tokens[i] != *TOKENS[LOOKUP[tokens[i].Id]]) {
             return false
         }
     }


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6c03ff]

goroutine 19 [running]:
server.interrogate(0xc0003626e0, 0x3, 0x4, 0x2)
	/home/albert/Home/slanet/server/src/server/server.go:205 +0xaf
server.relay()
	/home/albert/Home/slanet/server/src/server/server.go:222 +0x201
created by server.Run
	/home/albert/Home/slanet/server/src/server/server.go:245 +0x1c5
```